### PR TITLE
feat: add support for co2 sensors

### DIFF
--- a/mqtt_to_influx/converters/co2.py
+++ b/mqtt_to_influx/converters/co2.py
@@ -1,0 +1,16 @@
+"""
+Sensors report their CO2 level in ppm.
+
+Example:
+    988
+"""
+
+
+def convert_measurement(data):
+    payload = {
+        "co2": {
+            "value": data,
+            "unit": "ppm",
+        },
+    }
+    return payload

--- a/mqtt_to_influx/converters/co2_humidity
+++ b/mqtt_to_influx/converters/co2_humidity
@@ -1,0 +1,16 @@
+"""
+Co2 sensors report their humidity in percentage.
+
+Example:
+    45.17384
+"""
+
+
+def convert_measurement(data):
+    payload = {
+        "co2_humidity": {
+            "value": data,
+            "unit": "%",
+        },
+    }
+    return payload

--- a/mqtt_to_influx/converters/co2_temperature.py
+++ b/mqtt_to_influx/converters/co2_temperature.py
@@ -1,0 +1,16 @@
+"""
+Co2 sensors report their temperature in celsius.
+
+Example:
+    24.9034
+"""
+
+
+def convert_measurement(data):
+    payload = {
+        "co2_temperature": {
+            "value": data,
+            "unit": "°C",
+        },
+    }
+    return payload


### PR DESCRIPTION
Although all three sensors are from one device, they are reported in 3 MQTT topics; so we need three converters.